### PR TITLE
*: python3-ify

### DIFF
--- a/asmdiff.py
+++ b/asmdiff.py
@@ -9,10 +9,11 @@ import sys
 
 class Demangler:
     def __init__(self):
-        self.p = Popen(['c++filt'], stdin=PIPE, stdout=PIPE)
+        self.p = Popen(['c++filt'], stdin=PIPE, stdout=PIPE, text=True)
 
     def demangle(self, name):
         self.p.stdin.write('%s\n' % name)
+        self.p.stdin.flush()
         return self.p.stdout.readline().rstrip()
 
 class Instruction:
@@ -289,14 +290,14 @@ class MatchupSet:
         self.new_to_old = {}
         self.gone = []
         self.appeared = []
-        for olditem in old.iteritems():
+        for olditem in old.items():
             newitem = self._lookup(olditem)
             if newitem:
                 self.old_to_new[olditem] = newitem
                 self.new_to_old[newitem] = olditem
             else:
                 self.gone.append(olditem)
-        for newitem in new.iteritems():
+        for newitem in new.items():
             if newitem not in self.new_to_old:
                 self.appeared.append(newitem)
 
@@ -310,7 +311,7 @@ class FunctionPeer(Peer):
         for function in asmfile.functions.values():
             self.fn_by_leafnames[function.leafname] = function
 
-    def iteritems(self):
+    def items(self):
         return self.asmfile.functions.values()
 
 class FunctionMatchupSet(MatchupSet):
@@ -343,7 +344,7 @@ def asm_diff(old, new, out, just_sizes):
             out.writeln('Function removed: %s' % gone)
         for appeared in peers.appeared:
             out.writeln('Function added: %s' % appeared)
-        for oldfn, newfn in peers.old_to_new.iteritems():
+        for oldfn, newfn in peers.old_to_new.items():
             fn_diff(oldfn, newfn, out, just_sizes)
 
 class Output:

--- a/test_asmdiff.py
+++ b/test_asmdiff.py
@@ -1,4 +1,4 @@
-import StringIO
+import io
 import unittest
 
 from asmdiff import read_objdump, FunctionMatchupSet, fn_equal, \
@@ -73,7 +73,7 @@ class TestDiff(unittest.TestCase):
         """
         Run the diff tool, getting the output as a str
         """
-        strio = StringIO.StringIO()
+        strio = io.StringIO()
         asm_diff(old, new, Output(strio), just_sizes)
         return strio.getvalue()
 


### PR DESCRIPTION
- Replace iteritems with items
- Pass text=True to Popen, to tell Python that c++filt operates on text
- Replace the old StringIO module with ``io'', which contains a functionally identical (for our use) StringIO class.